### PR TITLE
Skip 'yarn test' in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ install:
   - npm install
   - npm run build
 
+script: echo 'skip test' # Skip `yarn test`
+
 deploy:
   local_dir: ./dist
   provider: pages


### PR DESCRIPTION
因為我們沒有測試，所以關閉 TravisCI 上的 `yarn test`。
scripts 改成  echo 'skip test' 略過測試。